### PR TITLE
fix: payment status flow + deposit visibility (v2.0.17)

### DIFF
--- a/app/Controllers/PublicSite/BookingController.php
+++ b/app/Controllers/PublicSite/BookingController.php
@@ -249,12 +249,12 @@ class BookingController extends BaseController
                 'slot_start' => (string) ($payload['start'] ?? ''),
             ]);
             $result = $this->booking->createBooking($payload);
-            $appointmentId = (int) ($result['appointment']['id'] ?? 0);
-            $serviceId     = (int) ($result['appointment']['service_id'] ?? 0);
+            $appointmentId = (int) ($result['appointment_id'] ?? 0);
+            $serviceId     = (int) ($result['service_id'] ?? 0);
 
             log_structured('info', 'public_booking.created', [
                 'appointment_id' => $appointmentId,
-                'provider_id' => isset($result['appointment']['provider_id']) ? (int) $result['appointment']['provider_id'] : null,
+                'provider_id' => isset($result['provider_id']) ? (int) $result['provider_id'] : null,
                 'service_id' => $serviceId,
             ]);
 
@@ -597,8 +597,12 @@ class BookingController extends BaseController
                 $cancelUrl . '?gateway=payfast',
                 $baseUrl . 'public/payments/payfast/notify'
             );
-            $response['payfast'] = $result;
-            $response['gateway'] = 'payfast';
+            if (!($result['ok'] ?? false)) {
+                $response['payment_error'] = $result['error'] ?? 'Payment could not be initiated. Please contact us to arrange payment.';
+            } else {
+                $response['payfast'] = $result;
+                $response['gateway'] = 'payfast';
+            }
         } elseif ($gateway === 'stripe' && ($meta['stripe_available'] ?? false)) {
             $result = $paymentSvc->initiateStripe(
                 $businessId,
@@ -607,8 +611,12 @@ class BookingController extends BaseController
                 $returnUrl . '?gateway=stripe&session_id={CHECKOUT_SESSION_ID}',
                 $cancelUrl . '?gateway=stripe'
             );
-            $response['stripe'] = $result;
-            $response['gateway'] = 'stripe';
+            if (!($result['ok'] ?? false)) {
+                $response['payment_error'] = $result['error'] ?? 'Payment could not be initiated. Please contact us to arrange payment.';
+            } else {
+                $response['stripe'] = $result;
+                $response['gateway'] = 'stripe';
+            }
         }
 
         // A gateway was selected but wasn't available (credentials missing or disabled).

--- a/app/Database/Migrations/2026-06-09-100000_AddPaymentInfoToPendingTemplates.php
+++ b/app/Database/Migrations/2026-06-09-100000_AddPaymentInfoToPendingTemplates.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Database\Migrations;
+
+use App\Database\MigrationBase;
+
+/**
+ * Adds {payment_info} placeholder to the seeded appointment_pending templates
+ * so customers are informed of an outstanding deposit when their booking is
+ * awaiting payment confirmation.
+ *
+ * buildPaymentInfoBlock() now returns a "Deposit due" block for payment_status='pending'
+ * (in addition to the existing "Deposit paid" block for payment_status='paid').
+ * When no deposit applies, {payment_info} resolves to '' — templates are unaffected
+ * for non-payment bookings.
+ *
+ * Template priority: xs_settings > xs_message_templates > DEFAULT_TEMPLATES (code)
+ * This migration patches xs_settings rows so the change takes effect immediately.
+ */
+class AddPaymentInfoToPendingTemplates extends MigrationBase
+{
+    private const PENDING_EMAIL_KEY = 'notification_template.appointment_pending.email';
+    private const PENDING_WA_KEY    = 'notification_template.appointment_pending.whatsapp';
+
+    public function up(): void
+    {
+        $builder = $this->db->table('xs_settings');
+
+        // ── 1. Patch appointment_pending email to include {payment_info} ─────────
+        $row = $builder->where('setting_key', self::PENDING_EMAIL_KEY)->get()->getRow();
+        if ($row) {
+            $template = json_decode($row->setting_value ?? '{}', true) ?? [];
+            $body = $template['body'] ?? '';
+            if (strpos($body, '{payment_info}') === false) {
+                // Insert after the booking reference line, before customer name
+                $body = str_replace(
+                    "\nBOOKING REFERENCE: #{booking_reference}\nName:",
+                    "\nBOOKING REFERENCE: #{booking_reference}\n{payment_info}Name:",
+                    $body
+                );
+                $template['body'] = $body;
+                $builder->where('setting_key', self::PENDING_EMAIL_KEY)
+                        ->update(['setting_value' => json_encode($template)]);
+            }
+        }
+
+        // ── 2. Patch appointment_pending WhatsApp to include {payment_info} ─────
+        $row = $builder->where('setting_key', self::PENDING_WA_KEY)->get()->getRow();
+        if ($row) {
+            $template = json_decode($row->setting_value ?? '{}', true) ?? [];
+            $body = $template['body'] ?? '';
+            if (strpos($body, '{payment_info}') === false) {
+                $body = str_replace(
+                    "\n*Booking Ref:* #{booking_reference}\n",
+                    "\n*Booking Ref:* #{booking_reference}\n{payment_info}\n",
+                    $body
+                );
+                $template['body'] = $body;
+                $builder->where('setting_key', self::PENDING_WA_KEY)
+                        ->update(['setting_value' => json_encode($template)]);
+            }
+        }
+    }
+
+    public function down(): void
+    {
+        // Non-destructive patch — {payment_info} resolves to '' for non-payment
+        // bookings so templates degrade gracefully. No rollback needed.
+    }
+}

--- a/app/Services/Appointment/AppointmentFormatterService.php
+++ b/app/Services/Appointment/AppointmentFormatterService.php
@@ -100,6 +100,10 @@ class AppointmentFormatterService
             // Delivery mode
             'delivery_mode'    => (string) ($row['delivery_mode'] ?? 'onsite'),
             'video_link'       => (string) ($row['video_link']    ?? ''),
+            // Payment / deposit
+            'payment_status'    => $row['payment_status']    ?? 'none',
+            'payment_amount'    => isset($row['payment_amount']) ? (float) $row['payment_amount'] : null,
+            'payment_reference' => $row['payment_reference'] ?? null,
         ];
     }
 

--- a/app/Services/NotificationTemplateService.php
+++ b/app/Services/NotificationTemplateService.php
@@ -136,13 +136,13 @@ class NotificationTemplateService
         'appointment_pending' => [
             'email' => [
                 'subject' => 'Your Appointment Request is Received — {service_name}',
-                'body' => "Hi {customer_first_name},\n\nWe've received your booking request! We will confirm your appointment shortly.\n\n── APPOINTMENT DETAILS ──────────────────\n📅 Date:      {appointment_date}\n🕐 Time:      {appointment_time}\n💼 Service:   {service_name}\n👤 Provider:  {provider_name}\n⏱  Duration: {service_duration} minutes\n{session_info}\n☎ Enquiries: {business_email} | Tel: {business_phone}\n\n🕰 Business Hours:\n{business_hours}\n─────────────────────────────────────────\n\nBOOKING REFERENCE: #{booking_reference}\nName:    {customer_name}\nContact: {customer_phone} | {customer_email}\n\nWe will notify you as soon as your appointment is confirmed.\n\n{cancellation_policy}\n{rescheduling_policy}\n\n── MANAGE YOUR APPOINTMENT ──────────────\nOpen secure link: {reschedule_link}\nIf the link is not clickable, copy and paste this URL:\n{reschedule_link}\nAdd to Google Calendar: {calendar_link}\n\n{business_name}\n{terms_link} | {privacy_link}"
+                'body' => "Hi {customer_first_name},\n\nWe've received your booking request! We will confirm your appointment shortly.\n\n── APPOINTMENT DETAILS ──────────────────\n📅 Date:      {appointment_date}\n🕐 Time:      {appointment_time}\n💼 Service:   {service_name}\n👤 Provider:  {provider_name}\n⏱  Duration: {service_duration} minutes\n{session_info}\n☎ Enquiries: {business_email} | Tel: {business_phone}\n\n🕰 Business Hours:\n{business_hours}\n─────────────────────────────────────────\n\nBOOKING REFERENCE: #{booking_reference}\n{payment_info}Name:    {customer_name}\nContact: {customer_phone} | {customer_email}\n\nWe will notify you as soon as your appointment is confirmed.\n\n{cancellation_policy}\n{rescheduling_policy}\n\n── MANAGE YOUR APPOINTMENT ──────────────\nOpen secure link: {reschedule_link}\nIf the link is not clickable, copy and paste this URL:\n{reschedule_link}\nAdd to Google Calendar: {calendar_link}\n\n{business_name}\n{terms_link} | {privacy_link}"
             ],
             'sms' => [
                 'body' => "⏳ Booking received! {service_name} on {appointment_date} at {appointment_time}. Pending confirmation. Ref #{booking_reference}. Manage: {reschedule_link}"
             ],
             'whatsapp' => [
-                'body' => "⏳ *Appointment Request Received*\n\nHi {customer_first_name}!\n\nWe've received your booking request and will confirm your appointment shortly.\n\n*📅 Date:* {appointment_date}\n*🕐 Time:* {appointment_time}\n*💼 Service:* {service_name}\n*👤 Provider:* {provider_name}\n*⏱ Duration:* {service_duration} minutes\n{session_info}\n\n*Booking Ref:* #{booking_reference}\n\n{cancellation_policy}\n\nView / Reschedule / Cancel: {reschedule_link}\nAdd to Calendar: {calendar_link}\n\nWe will notify you once confirmed.\n\n_{business_name}_\n{terms_link} | {privacy_link}"
+                'body' => "⏳ *Appointment Request Received*\n\nHi {customer_first_name}!\n\nWe've received your booking request and will confirm your appointment shortly.\n\n*📅 Date:* {appointment_date}\n*🕐 Time:* {appointment_time}\n*💼 Service:* {service_name}\n*👤 Provider:* {provider_name}\n*⏱ Duration:* {service_duration} minutes\n{session_info}\n\n*Booking Ref:* #{booking_reference}\n{payment_info}\n{cancellation_policy}\n\nView / Reschedule / Cancel: {reschedule_link}\nAdd to Calendar: {calendar_link}\n\nWe will notify you once confirmed.\n\n_{business_name}_\n{terms_link} | {privacy_link}"
             ]
         ],
         'appointment_confirmed' => [
@@ -754,33 +754,44 @@ class NotificationTemplateService
     }
 
     /**
-     * Build the payment info block inserted into `appointment_confirmed` templates.
-     * Returns a formatted multi-line section when payment_status='paid', else ''.
+     * Build the payment info block for notification templates.
+     * Returns a formatted multi-line section for paid or pending-payment appointments.
+     * Returns '' when no deposit applies (payment_status = 'none' / no amount set).
      */
     private function buildPaymentInfoBlock(array $data): string
     {
-        if (($data['payment_status'] ?? '') !== 'paid' || empty($data['payment_amount'])) {
-            return '';
+        $status = (string) ($data['payment_status'] ?? '');
+        $amount = empty($data['payment_amount']) ? 0.0 : (float) $data['payment_amount'];
+        $ref    = (string) ($data['payment_reference'] ?? '');
+
+        if ($status === 'paid' && $amount > 0) {
+            $loc     = new LocalizationSettingsService();
+            $price   = (float) ($data['service_price'] ?? 0);
+            $balance = $price > 0 ? max(0.0, $price - $amount) : 0.0;
+            $lines   = [];
+            $lines[] = "── PAYMENT ──────────────────────────────";
+            $lines[] = "💳 Deposit paid:    " . $loc->formatCurrency($amount);
+            if ($balance > 0) {
+                $lines[] = "💰 Outstanding:     " . $loc->formatCurrency($balance) . " (payable on the day)";
+            }
+            if ($ref !== '') {
+                $lines[] = "🔑 Payment ref:     " . $ref;
+            }
+            $lines[] = "─────────────────────────────────────────";
+            return implode("\n", $lines) . "\n";
         }
 
-        $loc     = new LocalizationSettingsService();
-        $paid    = (float) $data['payment_amount'];
-        $price   = (float) ($data['service_price'] ?? 0);
-        $balance = $price > 0 ? max(0.0, $price - $paid) : 0.0;
-        $ref     = (string) ($data['payment_reference'] ?? '');
-
-        $lines   = [];
-        $lines[] = "── PAYMENT ──────────────────────────────";
-        $lines[] = "💳 Deposit paid:    " . $loc->formatCurrency($paid);
-        if ($balance > 0) {
-            $lines[] = "💰 Outstanding:     " . $loc->formatCurrency($balance) . " (payable on the day)";
+        if ($status === 'pending' && $amount > 0) {
+            $loc     = new LocalizationSettingsService();
+            $lines   = [];
+            $lines[] = "── DEPOSIT REQUIRED ─────────────────────";
+            $lines[] = "💳 Deposit due:     " . $loc->formatCurrency($amount);
+            $lines[] = "   Your appointment will be confirmed once payment is received.";
+            $lines[] = "─────────────────────────────────────────";
+            return implode("\n", $lines) . "\n";
         }
-        if ($ref !== '') {
-            $lines[] = "🔑 Payment ref:     " . $ref;
-        }
-        $lines[] = "─────────────────────────────────────────";
 
-        return implode("\n", $lines) . "\n";
+        return '';
     }
 
     /**

--- a/app/Services/PayFastIntegrationService.php
+++ b/app/Services/PayFastIntegrationService.php
@@ -255,6 +255,10 @@ class PayFastIntegrationService
         $passphrase  = (string) ($config['passphrase'] ?? '');
         $sandbox     = (bool) ($config['sandbox'] ?? true);
 
+        if ($merchantId === '' || $merchantKey === '') {
+            return ['ok' => false, 'error' => 'PayFast merchant credentials are missing or could not be decrypted.'];
+        }
+
         $baseUrl  = $sandbox ? 'https://sandbox.payfast.co.za/eng/process' : 'https://www.payfast.co.za/eng/process';
 
         $fields = array_filter([

--- a/app/Services/PublicBookingService.php
+++ b/app/Services/PublicBookingService.php
@@ -672,7 +672,10 @@ class PublicBookingService
             }
         }
 
-        return $this->formatPublicAppointment($appointment, $token);
+        return array_merge(
+            ['appointment_id' => $appointmentId],
+            $this->formatPublicAppointment($appointment, $token)
+        );
     }
 
     public function lookupAppointment(string $token, ?string $email = null, ?string $phone = null, ?string $phoneCountryCode = null): array

--- a/app/Services/PublicBookingService.php
+++ b/app/Services/PublicBookingService.php
@@ -653,6 +653,16 @@ class PublicBookingService
             'booking_channel' => 'public',
         ];
 
+        // Payment-gate: force 'pending' regardless of admin default when deposit is due.
+        // Appointment only transitions pending→confirmed when PayFast/Stripe ITN is received.
+        if ((bool) ($service['payment_enabled'] ?? false)) {
+            $pmeta = (new \App\Services\Payment\PaymentService())->servicePaymentMeta($service, 1);
+            if (($pmeta['payment_required'] ?? false)
+                && (($pmeta['payfast_available'] ?? false) || ($pmeta['stripe_available'] ?? false))) {
+                $bookingPayload['status'] = \App\Services\Appointment\AppointmentStatus::PENDING;
+            }
+        }
+
         $result = $this->bookingService->createAppointment($bookingPayload, $this->localization->getTimezone());
         if (!$result['success']) {
             throw new PublicBookingException(

--- a/app/Views/appointments/form.php
+++ b/app/Views/appointments/form.php
@@ -125,8 +125,13 @@ $pageSubtitle = $isEditMode
         <span class="text-gray-500 dark:text-gray-400">&middot;</span>
         <span class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-semibold bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400">
             <span class="material-symbols-outlined text-xs">schedule</span>
-            Payment pending
+            Payment pending<?= $pAmount ? ' &mdash; ' . (function_exists('format_currency') ? format_currency((float)$pAmount) : 'R'.number_format((float)$pAmount, 2)) . ' due' : '' ?>
         </span>
+        <?php endif ?>
+        <?php $pRef = $appointment['payment_reference'] ?? null; ?>
+        <?php if ($pRef && in_array($pStatus, ['paid', 'pending'], true)): ?>
+        <span class="text-gray-500 dark:text-gray-400">&middot;</span>
+        <span class="text-xs text-gray-500 dark:text-gray-400">Ref: <?= esc($pRef) ?></span>
         <?php endif ?>
     </div>
     <?php endif ?>

--- a/app/Views/customer-management/history.php
+++ b/app/Views/customer-management/history.php
@@ -209,6 +209,7 @@
                         <th class="px-4 py-3 font-semibold">Service</th>
                         <th class="px-4 py-3 font-semibold">Provider</th>
                         <th class="px-4 py-3 font-semibold">Status</th>
+                        <th class="px-4 py-3 font-semibold">Deposit</th>
                         <th class="px-4 py-3 font-semibold">Notes</th>
                         <th class="px-4 py-3 font-semibold">Actions</th>
                     </tr>
@@ -257,6 +258,25 @@
                                 <?= ucfirst(str_replace('-', ' ', esc($appt['status'] ?? ''))) ?>
                             </span>
                         </td>
+                        <td class="px-4 py-3">
+                            <?php
+                                $apptPStatus = $appt['payment_status'] ?? 'none';
+                                $apptPAmount = $appt['payment_amount'] ?? null;
+                                if ($apptPStatus === 'paid' && $apptPAmount):
+                            ?>
+                                <span class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-semibold bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400">
+                                    <span class="material-symbols-outlined text-xs">check_circle</span>
+                                    Paid <?= esc(function_exists('format_currency') ? format_currency((float)$apptPAmount) : 'R'.number_format((float)$apptPAmount, 2)) ?>
+                                </span>
+                            <?php elseif ($apptPStatus === 'pending'): ?>
+                                <span class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-semibold bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400">
+                                    <span class="material-symbols-outlined text-xs">schedule</span>
+                                    Pending<?= $apptPAmount ? ' ' . (function_exists('format_currency') ? format_currency((float)$apptPAmount) : 'R'.number_format((float)$apptPAmount, 2)) : '' ?>
+                                </span>
+                            <?php else: ?>
+                                <span class="text-xs text-gray-400">—</span>
+                            <?php endif ?>
+                        </td>
                         <td class="px-4 py-3 max-w-xs truncate text-gray-500 dark:text-gray-400">
                             <?= esc($appt['notes'] ?? '—') ?>
                         </td>
@@ -270,7 +290,7 @@
                     <?php endforeach; ?>
                 <?php else: ?>
                     <tr>
-                        <td colspan="6" class="px-4 py-8 text-center text-gray-500 dark:text-gray-400">
+                        <td colspan="7" class="px-4 py-8 text-center text-gray-500 dark:text-gray-400">
                             <span class="material-symbols-outlined text-4xl mb-2 block">event_busy</span>
                             No appointments found.
                         </td>

--- a/resources/js/modules/scheduler/appointment-details-modal.js
+++ b/resources/js/modules/scheduler/appointment-details-modal.js
@@ -163,6 +163,18 @@ export class AppointmentDetailsModal {
                                 </div>
                             </div>
                             
+                            <!-- Payment / Deposit Section -->
+                            <div id="detail-payment-wrapper" class="hidden rounded-lg p-3 border">
+                                <div class="flex items-start gap-3">
+                                    <span class="material-symbols-outlined text-xl" id="detail-payment-icon">payments</span>
+                                    <div class="flex-1">
+                                        <h4 class="text-xs font-medium text-gray-500 dark:text-gray-400 mb-1">Deposit</h4>
+                                        <p id="detail-payment-status-badge" class="text-sm font-semibold"></p>
+                                        <p id="detail-payment-ref" class="text-xs text-gray-500 dark:text-gray-400 mt-0.5 hidden"></p>
+                                    </div>
+                                </div>
+                            </div>
+
                             <!-- Notes Section -->
                             <div id="detail-notes-wrapper">
                                 <h4 class="text-xs font-medium text-gray-500 dark:text-gray-400 mb-2 flex items-center gap-2">
@@ -493,6 +505,39 @@ export class AppointmentDetailsModal {
                 videoLinkWrapper.classList.add('hidden');
             }
             
+            // Payment / deposit
+            const paymentWrapper = this.modal.querySelector('#detail-payment-wrapper');
+            const paymentBadge   = this.modal.querySelector('#detail-payment-status-badge');
+            const paymentIcon    = this.modal.querySelector('#detail-payment-icon');
+            const paymentRef     = this.modal.querySelector('#detail-payment-ref');
+            const pStatus = appointment.payment_status || 'none';
+            const pAmount = appointment.payment_amount;
+            if (pStatus === 'paid' && pAmount) {
+                paymentWrapper.classList.remove('hidden');
+                paymentWrapper.className = 'rounded-lg p-3 border bg-green-50 dark:bg-green-900/20 border-green-200 dark:border-green-800';
+                paymentIcon.className    = 'material-symbols-outlined text-xl text-green-600 dark:text-green-400';
+                paymentBadge.className   = 'text-sm font-semibold text-green-800 dark:text-green-200';
+                const fmt = this.scheduler.settingsManager?.formatCurrency(pAmount) ?? pAmount;
+                paymentBadge.textContent = `Deposit paid: ${fmt}`;
+            } else if (pStatus === 'pending') {
+                paymentWrapper.classList.remove('hidden');
+                paymentWrapper.className = 'rounded-lg p-3 border bg-amber-50 dark:bg-amber-900/20 border-amber-200 dark:border-amber-800';
+                paymentIcon.className    = 'material-symbols-outlined text-xl text-amber-600 dark:text-amber-400';
+                paymentBadge.className   = 'text-sm font-semibold text-amber-800 dark:text-amber-200';
+                const amtStr = pAmount
+                    ? `: ${this.scheduler.settingsManager?.formatCurrency(pAmount) ?? pAmount}`
+                    : '';
+                paymentBadge.textContent = `Payment pending${amtStr}`;
+            } else {
+                paymentWrapper.classList.add('hidden');
+            }
+            if (appointment.payment_reference) {
+                paymentRef.textContent = `Ref: ${appointment.payment_reference}`;
+                paymentRef.classList.remove('hidden');
+            } else {
+                paymentRef.classList.add('hidden');
+            }
+
             // Notes - set textarea value and track changes
             const notesTextarea = this.modal.querySelector('#detail-notes');
             const saveNotesBtn = this.modal.querySelector('#btn-save-notes');


### PR DESCRIPTION
## Summary

- **Payment status gate** — public bookings for payment-required services now start as `pending`; only the PayFast/Stripe ITN webhook transitions to `confirmed`. Previously, appointments would auto-confirm at creation regardless of payment.
- **Scheduler calendar modal** — new amber/green Deposit section showing pending amount or confirmed paid amount + payment reference.
- **Appointment edit form** — pending badge now includes the amount due and payment reference number.
- **Customer Management → History** — new Deposit column with paid/pending badges per appointment row.
- **Pending notification templates** — `{payment_info}` added to `appointment_pending` email and WhatsApp defaults; `buildPaymentInfoBlock()` extended to show "Deposit due" for `payment_status='pending'` (previously returned empty string).
- **Migration** `2026-06-09-100000` — idempotently patches any existing custom pending templates in `xs_settings`.
- **notify_url fix** (already committed) — `public/payments/payfast/notify` correctly matches the `public/payments` route group; ITN delivery was broken.

## Test plan

- [ ] Book a payment-required service via the public booking form
- [ ] Confirm appointment created with `status = pending` (not confirmed) in DB
- [ ] Open appointment on scheduler calendar → Details Modal shows amber "Payment pending: R{x}"
- [ ] Open customer history (Customer Management) → Deposit column shows "Pending R{x}"
- [ ] Open appointment edit form → pending badge shows amount + Ref line
- [ ] Complete PayFast sandbox payment with a **different email** than the merchant account
- [ ] Confirm ITN arrives at `POST /public/payments/payfast/notify` (check logs)
- [ ] Confirm appointment transitions `pending → confirmed`, `payment_status → paid`
- [ ] Reopen details modal → green "Deposit paid: R{x}" shown
- [ ] Run `php spark migrate -n App` after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)